### PR TITLE
REFACTOR: move demo state into a class

### DIFF
--- a/demo_scripts/script.md
+++ b/demo_scripts/script.md
@@ -7,6 +7,12 @@ tutorials within this directory:
 ls -d */
 ```
 
+Results:
+
+```
+simdem/  test/
+```
+
 To run one of these demos using the latest development code run
 `python3 simdem.py run <DEMO_NAME>` from within the SimDem root
 directory, for example:

--- a/demo_scripts/simdem/script.md
+++ b/demo_scripts/simdem/script.md
@@ -144,7 +144,7 @@ The SimDem application has the following setup:
 tree ..
 ```
 
-Results:
+Results: Expected Similarity: 0.5
 
 ```
 demo_scripts/

--- a/simdem.py
+++ b/simdem.py
@@ -153,7 +153,7 @@ def simulate_command(demo):
     type_command(demo.current_command, demo.script_dir, demo.is_simulation)
     check_for_interactive_command(demo.script_dir, demo.is_automated)
     print()
-    output = run_command(demo.current_command, demo.script_dir, demo.env)
+    output = run_command(demo)
 
     return output
 
@@ -193,17 +193,17 @@ def get_simdem_environment(directory):
     
     return env
 
-def run_command(command, script_dir, env=None):
-    if command.startswith("sudo "):
-        is_docker_command = 'if [ -f /.dockerenv ]; then echo "True"; else echo "False"; fi'
-        shell = pexpect.spawnu('/bin/bash', ['-c', is_docker_command], env=env, cwd=script_dir, timeout=None)
+def run_command(demo):
+    if demo.current_comment.startswith("sudo "):
+        is_docker = 'if [ -f /.dockerenv ]; then echo "True"; else echo "False"; fi'
+        shell = pexpect.spawnu('/bin/bash', ['-c', is_docker], env=demo.env, cwd=demo.script_dir, timeout=None)
         shell.expect(pexpect.EOF)
         is_docker = shell.before.strip() == "True"
         if is_docker:
             command = command[5:]
 
     print(colorama.Fore.GREEN+colorama.Style.BRIGHT)
-    shell = pexpect.spawnu('/bin/bash', ['-c', command], env=env, cwd=script_dir, timeout=None)
+    shell = pexpect.spawnu('/bin/bash', ['-c', demo.current_command], env=demo.env, cwd=demo.script_dir, timeout=None)
     shell.logfile = sys.stdout
     shell.expect(pexpect.EOF)
     print(colorama.Style.RESET_ALL)

--- a/simdem.py
+++ b/simdem.py
@@ -23,6 +23,7 @@ class Demo(object):
         self.is_simulation = is_simulation
         self.is_automated = is_automated
         self.is_testing = is_testing
+        self.current_comment = ""
 
     def run(self):
         # Reads a script.md file in the indicated directoy and runs the
@@ -90,7 +91,8 @@ class Demo(object):
                 # Executable line
                 print("$ ", end="", flush=True)
                 check_for_interactive_command(self.script_dir, self.is_automated)
-                actual_results = simulate_command(line, self.script_dir, self.env, self.is_simulation, self.is_automated)
+                self.current_command = line
+                actual_results = simulate_command(self)
                 executed_code_in_this_section = True
             elif line.startswith("#") and not in_code_block and not in_results_section and not self.is_automated:
                 # Heading in descriptive text, indicating a new section
@@ -100,7 +102,8 @@ class Demo(object):
                     executed_code_in_this_section = False
                     print("$ ", end="", flush=True)
                     check_for_interactive_command(script_dir, self.is_automated)
-                    simulate_command("clear", script_dir, env, self.is_simulation, self.is_automated)
+                    self.current_command = "clear"
+                    simulate_command(self)
                     if not is_simulation:
                         print("$ ", end="", flush=True)
                         # Since this is a heading we are not really simulating a command, it appears as a comment
@@ -142,15 +145,15 @@ def type_command(command, script_dir, simulation):
             time.sleep(delay)
     print(colorama.Style.RESET_ALL, end="")
 
-def simulate_command(command, script_dir, env = None, simulation = True, is_automatic=False):
+def simulate_command(demo):
     # Types the command on the screen, executes it and outputs the
     # results if simulation == True then system will make the "typing"
     # look real and will wait for keyboard entry before proceeding to
     # the next command
-    type_command(command, script_dir, simulation)
-    check_for_interactive_command(script_dir, is_automatic)
+    type_command(demo.current_command, demo.script_dir, demo.is_simulation)
+    check_for_interactive_command(demo.script_dir, demo.is_automated)
     print()
-    output = run_command(command, script_dir, env)
+    output = run_command(demo.current_command, demo.script_dir, demo.env)
 
     return output
 

--- a/simdem.py
+++ b/simdem.py
@@ -96,17 +96,17 @@ class Demo(object):
             elif line.startswith("#") and not in_code_block and not in_results_section and not self.is_automated:
                 # Heading in descriptive text, indicating a new section
                 if is_first_line:
-                    run_command(demo, "clear")
+                    run_command(self, "clear")
                 elif executed_code_in_this_section:
                     executed_code_in_this_section = False
                     print("$ ", end="", flush=True)
-                    check_for_interactive_command(script_dir, self.is_automated)
+                    check_for_interactive_command(self)
                     self.current_command = "clear"
                     simulate_command(self)
-                    if not is_simulation:
+                    if not self.is_simulation:
                         print("$ ", end="", flush=True)
                         # Since this is a heading we are not really simulating a command, it appears as a comment
-                        simulate_command(line, script_dir, env, is_simulation, is_automated)
+                        simulate_command(self)
             elif not self.is_simulation and not in_results_section:
                 # Descriptive text
                 print(colorama.Fore.CYAN, end = "") 


### PR DESCRIPTION
The more features we add that require state and configuration variables the more values we are passing around the functions. It is starting to get difficult to track/maintain. Rather than use global variables (which I personally dislike due to the ease of creating side effects) I've opted to break out a demo class.

This class maintains the state of the demo and controls its execution. The command execution commands remain in the main Python file at this time.

I have no broken the class out into its own file as part of this PR though this is likely good to do in the future.