### PR TITLE
Add a help and description command

### DIFF
--- a/demo_scripts/test/script.md
+++ b/demo_scripts/test/script.md
@@ -27,6 +27,19 @@ Results:
 }
 ```
 
+# Code comments
+
+'''
+# This is a comment and should be ignored
+echo "This output should be displayed"
+```
+
+Results:
+
+```
+This output should be displayed
+```
+
 # Expected different results
 
 When we know the results will be different and we want to use them in

--- a/demo_scripts/test/script.md
+++ b/demo_scripts/test/script.md
@@ -31,13 +31,13 @@ Results:
 
 ```
 # This is a comment and should be ignored
-echo "This output should be displayed"
+echo "This output should be displayed, the comment before this line should be ignored"
 ```
 
 Results:
 
 ```
-This output should be displayed
+This output should be displayed, the comment before this line should be ignored
 ```
 
 # Expected different results

--- a/demo_scripts/test/script.md
+++ b/demo_scripts/test/script.md
@@ -29,7 +29,7 @@ Results:
 
 # Code comments
 
-'''
+```
 # This is a comment and should be ignored
 echo "This output should be displayed"
 ```

--- a/simdem.py
+++ b/simdem.py
@@ -84,7 +84,7 @@ def run_command(command, script_dir, env=None):
         if is_docker:
             command = command[5:]
 
-    print(colorama.Fore.GREEN+colorama.Style.BRIGHT)
+    print(colorama.Fore.GREEN+colorama.Style.BRIGHT, end="")
     shell = pexpect.spawnu('/bin/bash', ['-c', command], env=env, cwd=script_dir, timeout=None)
     shell.logfile = sys.stdout
     shell.expect(pexpect.EOF)
@@ -95,12 +95,28 @@ def check_for_interactive_command(script_dir, is_automated=False):
     # Wait for a key to be pressed. Most keys result in the script
     # progressing, but a few have special meaning. See the
     # documentation or code for a description of the special keys.
-    if is_automated:
-        return
     
     key = get_instruction_key()
-    
-    if key == 'b' or key == 'B':
+
+    if key == 'h':
+        print("help")
+        print()
+        print("SimDem Help")
+        print("===========")
+        print()
+        print("Pressing any key other than those listed below will result in the script progressing")
+        print()
+        print("'b'           - break out of the script and accept a command from user input")
+        print("'b' -> CTRL-C - stop the script")
+        print("'h'           - displays this help message")
+        print()
+        print("Press SPACEBAR to continue")
+        while key != ' ':
+            key = get_instruction_key()
+        print()
+        print("$ ", end = "", flush = True)
+        check_for_interactive_command(script_dir, is_automated)
+    elif key == 'b':
         command = input()
         run_command(command, script_dir)
         print("$ ", end="", flush=True)

--- a/simdem.py
+++ b/simdem.py
@@ -88,11 +88,15 @@ class Demo(object):
                 expected_results += line
             elif in_code_block and not in_results_section:
                 # Executable line
-                print("$ ", end="", flush=True)
-                self.current_command = line
-                check_for_interactive_command(self)
-                actual_results = simulate_command(self)
-                executed_code_in_this_section = True
+                if line.startswith("#"):
+                    # comment
+                    pass
+                else:
+                    print("$ ", end="", flush=True)
+                    self.current_command = line
+                    check_for_interactive_command(self)
+                    actual_results = simulate_command(self)
+                    executed_code_in_this_section = True
             elif line.startswith("#") and not in_code_block and not in_results_section and not self.is_automated:
                 # Heading in descriptive text, indicating a new section
                 if is_first_line:

--- a/simdem.py
+++ b/simdem.py
@@ -95,14 +95,16 @@ def check_for_interactive_command(script_dir, is_automated=False):
     # Wait for a key to be pressed. Most keys result in the script
     # progressing, but a few have special meaning. See the
     # documentation or code for a description of the special keys.
-    if not is_automated:
-        key = get_instruction_key()
+    if is_automated:
+        return
     
-        if key == 'b' or key == 'B':
-            command = input()
-            run_command(command, script_dir)
-            print("$ ", end="", flush=True)
-            check_for_interactive_command(script_dir, is_automated)
+    key = get_instruction_key()
+    
+    if key == 'b' or key == 'B':
+        command = input()
+        run_command(command, script_dir)
+        print("$ ", end="", flush=True)
+        check_for_interactive_command(script_dir, is_automated)
 
 def get_instruction_key():
     """Waits for a single keypress on stdin.

--- a/simdem.py
+++ b/simdem.py
@@ -122,6 +122,7 @@ class Demo(object):
         in_results_section = False
         expected_results = ""
         actual_results = ""
+        current_description = ""
         passed_tests = 0
         failed_tests = 0
         is_first_line = True

--- a/simdem.py
+++ b/simdem.py
@@ -24,8 +24,9 @@ class Demo(object):
         self.is_simulation = is_simulation
         self.is_automated = is_automated
         self.is_testing = is_testing
-        self.current_comment = ""
-
+        self.current_command = ""
+        self.current_description = ""
+        
     def run(self):
         """
         Reads a script.md file in the indicated directoy and runs the
@@ -94,8 +95,8 @@ class Demo(object):
                     pass
                 else:
                     print("$ ", end="", flush=True)
-                    self.current_command = line
                     check_for_interactive_command(self)
+                    self.current_command = line
                     actual_results = simulate_command(self)
                     executed_code_in_this_section = True
             elif line.startswith("#") and not in_code_block and not in_results_section and not self.is_automated:
@@ -104,6 +105,7 @@ class Demo(object):
                     run_command(self, "clear")
                 elif executed_code_in_this_section:
                     executed_code_in_this_section = False
+                    self.current_description = ""
                     print("$ ", end="", flush=True)
                     check_for_interactive_command(self)
                     self.current_command = "clear"
@@ -112,11 +114,22 @@ class Demo(object):
                         print("$ ", end="", flush=True)
                         # Since this is a heading we are not really simulating a command, it appears as a comment
                         simulate_command(self)
-            elif not self.is_simulation and not in_results_section:
-                # Descriptive text
-                print(colorama.Fore.CYAN, end="")
+
+                print(colorama.Fore.CYAN + colorama.Style.BRIGHT, end="")
                 print(line, end="", flush=True)
                 print(colorama.Style.RESET_ALL, end="")
+                self.current_description += colorama.Fore.CYAN + colorama.Style.BRIGHT
+                self.current_description += line;
+                self.current_description += colorama.Style.RESET_ALL
+            else:
+                self.current_description += colorama.Fore.CYAN
+                self.current_description += line;
+                self.current_description += colorama.Style.RESET_ALL
+                if not self.is_simulation and not in_results_section:
+                    # Descriptive text
+                    print(colorama.Fore.CYAN, end="")
+                    print(line, end="", flush=True)
+                    print(colorama.Style.RESET_ALL, end="")
 
             is_first_line = False
 
@@ -162,7 +175,8 @@ def simulate_command(demo):
     check_for_interactive_command(demo)
     print()
     output = run_command(demo)
-
+    demo.current_command = ""
+    
     return output
 
 def get_simdem_environment(directory):
@@ -263,7 +277,7 @@ def check_for_interactive_command(demo):
         elif key =='d':
             print("")
             print(colorama.Fore.CYAN) 
-            print("FIXME: Earlier description goes here")
+            print(demo.current_description);
             print(colorama.Style.RESET_ALL)
             print("$ ", end="", flush=True)
             print(demo.current_command, end="", flush=True)

--- a/simdem.py
+++ b/simdem.py
@@ -247,9 +247,11 @@ def check_for_interactive_command(demo):
             check_for_interactive_command(demo)
         elif key =='d':
             print("")
+            print(colorama.Fore.CYAN) 
             print("FIXME: Earlier description goes here")
+            print(colorama.Style.RESET_ALL)
             print("$ ", end="", flush=True)
-            print("FIXME: current command goes here")
+            print(demo.current_command, end="", flush=True)
             check_for_interactive_command(demo)
 
 def get_instruction_key():


### PR DESCRIPTION
Add the ability to press 'h' to get some help text and 'd' to display the most recent description. This is useful when running in simulate mode (which does not print the description) if the user needs to understand why a command needs to be run. Press the 'd' and get details.

@suhaildawood can you review this please